### PR TITLE
feat: throw errors for wrong input

### DIFF
--- a/src/animation.ts
+++ b/src/animation.ts
@@ -2,6 +2,7 @@ import {Player, PlayerOptions} from "./player";
 import {isPresent, isNumber} from "./util";
 import {BrowserClock} from './browser_clock.ts';
 import {BrowserStyles} from './browser_styles';
+import {animationErrors} from './errors';
 
 export class Animation {
   options: PlayerOptions;
@@ -12,8 +13,15 @@ export class Animation {
               options: any,
               clock: BrowserClock = null,
               styles: BrowserStyles = null) {
-    if (isNumber(options)) {
+
+    if(arguments.length && !arguments[0]) {
+      throw new Error(animationErrors.nokeyframes);
+    }
+
+    if (isNumber(options) && options > 0) {
       options = { duration: options };
+    } else if (!isNumber(options.duration) || options.duration < 0) {
+      throw new Error(animationErrors.durationdouble);
     }
 
     this.options = new PlayerOptions(options);

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,5 @@
+export const animationErrors = {
+  nokeyframes: "Failed to execute 'animate' on 'Element': argument 1 must be keyframe object.",
+  partial: "Failed to execute 'animate' on 'Element': Partial keyframes are not supported",
+  durationdouble: "Failed to execute 'animate' on 'Element': duration must be a double"
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ if (true) {
   var globalStyles = new BrowserStyles();
 
   Element.prototype['animate'] = function(keyframes, options) {
+
     var element = this;
     var player = polyfill.animate(element, keyframes, options, globalClock, globalStyles);
     player.play();

--- a/src/player.ts
+++ b/src/player.ts
@@ -9,6 +9,7 @@ import {NumericalStyleCalculator} from './calculators/numerical_style_calculator
 import {TransformStyleCalculator} from './calculators/transform_style_calculator';
 import {ColorStyleCalculator} from './calculators/color_style_calculator';
 import {StyleCalculator} from './style_calculator';
+import {animationErrors} from './errors';
 
 export class AnimationPropertyEntry {
   constructor(public property: string, public calculator: StyleCalculator) {}
@@ -83,13 +84,24 @@ export class Player {
 
     var secondKeyframe = keyframes[1];
     forEach(secondKeyframe, (value, prop) => {
-      properties[prop].push(value);
+      if(properties[prop]) {
+        properties[prop].push(value);
+      } else {
+        throw new Error(animationErrors.partial);
+      }
     });
 
+    var previousFramePropsLength;
     this._animators = [];
     forEach(properties, (values, prop) => {
+      if (previousFramePropsLength && previousFramePropsLength !== prop.length) {
+        throw new Error(animationErrors.partial);
+      }
+
       var calculator = createCalculator(prop, values);
       this._animators.push(new AnimationPropertyEntry(prop, calculator));
+
+      previousFramePropsLength = prop.length;
     });
   }
 

--- a/test/player_spec.ts
+++ b/test/player_spec.ts
@@ -7,6 +7,7 @@ import {iit, xit, they, tthey, ddescribe} from './helpers';
 import {TRANSFORM_PROPERTIES, NO_UNIT, PX_UNIT, DEGREES_UNIT} from '../src/transform_properties';
 import {COLOR_PROPERTIES} from '../src/color_properties';
 import {isPresent} from '../src/util';
+import {animationErrors} from '../src/errors';
 
 function assertColor(element, prop, value) {
   var COLOR_REGEX = /rgba?\(\s*([^\),]+)\s*,\s*([^\),]+)\s*,\s*([^\),]+)\s*(?:,\s*([^\)]+)\s*)?\)*/;
@@ -499,4 +500,48 @@ describe('Player', () => {
       });
     });
   });
+
+  describe('error messages', () => {
+
+    it('should throw when no argument is passed to animate()', () => {
+      var element = el('div');
+
+      expect(() => {
+        animate(element);
+      }).toThrowError(Error, animationErrors.nokeyframes);
+    });
+
+    they('should throw when keyframe properties do not match', [
+      [
+        { background: 'red' },
+        { color: 'blue' }
+      ],
+      [
+        { background: 'red', color: 'red' },
+        { background: 'blue' }
+      ]
+    ], (keyframes) => {
+      var element = el('div');
+
+      expect(() => {
+        animate(element, keyframes, 1000);
+      }).toThrowError(Error, animationErrors.partial);
+    });
+
+    they('should throw when duration is not a positive double', [
+      false, true, 'string', {}, [], NaN, -1
+    ], (value) => {
+      var element = el('div');
+
+      expect(() => {
+        animate(element, [
+          { background: 'red' },
+          { background: 'blue' }
+        ], value);
+      }).toThrowError(Error, animationErrors.durationdouble);
+    });
+
+  });
+
+
 });


### PR DESCRIPTION
- when no keyframes are passed
- when keyframe properties don't match
- when duration is not a double

We are currently more strict than Chrome on this.
For example, Chrome allows undefined keyframes argument or negative duration.
I feel the spec is more thorough than this, though. Do we want to validate all the options? Easing etc.