### PR TITLE
Fix scoping issue due to arrow function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ var elementAnimateFn = window['$$elementAnimateFn'] = function(element, keyframe
 }
 
 if (!Element.prototype['animate']) {
-  Element.prototype['animate'] = (keyframes, options) => {
+  Element.prototype['animate'] = function (keyframes, options) {
     elementAnimateFn(this, keyframes, options);
   };
 }


### PR DESCRIPTION
Change `Element.prototype['animate']` method's `this` value to receiver
(the element `animate` is called on) by using normal function instead of
arrow function.

(Found by playing with demo in Safari which does not support animate)